### PR TITLE
Allow viewing offline devices

### DIFF
--- a/aurora_biologic/biologic.py
+++ b/aurora_biologic/biologic.py
@@ -154,10 +154,10 @@ class BiologicAPI:
                 msg = (
                     f"Device position {i}: serial number and name not found, "
                     "it may be disconnected, uninitialized, or a virtual device. "
-                    f"Naming the device 'OFFLINE_{i}'."
+                    f"Naming the device 'OFFLINE-{i}'."
                 )
                 logger.warning(msg)
-                device_name = f"OFFLINE_{i}"
+                device_name = f"OFFLINE-{i}"
             if not device_name:
                 device_name = sn
                 logger.warning(

--- a/aurora_biologic/biologic.py
+++ b/aurora_biologic/biologic.py
@@ -7,6 +7,7 @@ potentiostats.
 import functools
 import json
 import logging
+import re
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
@@ -47,6 +48,12 @@ with config_path.open("r") as f:
     CONFIG = json.load(f)
 serial_to_name = CONFIG.get("serial_to_name", {})
 serial_to_name = {int(k): v for k, v in serial_to_name.items()}
+if any(re.match(r"^OFFLINE-\d+$", v) for v in serial_to_name.values()):
+    msg = (
+        "Device name 'OFFLINE-{number}' is reserved for offline devices. "
+        "Please remove this from your config."
+    )
+    raise ValueError(msg)
 
 
 def open_eclab() -> None:

--- a/aurora_biologic/biologic.py
+++ b/aurora_biologic/biologic.py
@@ -192,6 +192,12 @@ class BiologicAPI:
         pipeline_dict = self._get_pipeline(pipeline)
         return pipeline_dict["device_index"], pipeline_dict["channel_index"]
 
+    def _assert_online(self, pipeline: str) -> None:
+        """Raise error if pipeline belongs to offline device."""
+        if not self._get_pipeline(pipeline).get("is_online"):
+            msg = "Device is offline"
+            raise ValueError(msg)
+
     ### EC-lab OLE-COM methods with retrying on failure ###
 
     @retry_with_backoff()
@@ -301,6 +307,7 @@ class BiologicAPI:
 
     def run_channel(self, pipeline: str, output_path: str | Path) -> None:
         """Run the protocol on the given pipeline."""
+        self._assert_online(pipeline)
         output_path = Path(output_path).resolve()
         if output_path.is_dir():
             msg = "Must provide a full file path, not directory."
@@ -317,6 +324,7 @@ class BiologicAPI:
 
     def stop(self, pipeline: str) -> None:
         """Stop the cycling process on a pipeline."""
+        self._assert_online(pipeline)
         dev_idx, channel_idx = self._get_pipeline_indices(pipeline)
         self._olecom_stop_channel(dev_idx, channel_idx)
 


### PR DESCRIPTION
Closes #3 

Previously, offline/virtual/uninitialised devices were skipped. Now, they are kept in the pipelines, named `OFFLINE_{x}` where x is index in EC-lab device list. This allows testing with virtual devices.

By default, offline devices are hidden, they can be seen by passing the `show_offline=True` or `--show-offline` option in Python or the CLI respectively.