### PR TITLE
Refactor, add wrapper funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ Rename your devices according to their serial number, and make sure the EC-lab e
 
 ## CLI usage
 
-Make sure EC-lab is running.
-
 You can check what devices and channels were found with
 ```bash
 biologic pipelines
@@ -95,19 +93,18 @@ biologic status MPG2-1-7
 
 ## API usage
 
-Commands can also be run using Python.
+Commands can also be run using Python, e.g.:
 
-Make sure EC-lab is running.
-
-Then commands can be run using the BiologicAPI object
 ```python
-from aurora_biologic import BiologicAPI
-with BiologicAPI() as bio:
-    bio.start(
-        "my_pipeline_id",
-        "path/to/my_experiment.mps",
-        "path/to/an/output.mpr",
-    )
+import aurora_biologic as bio
+
+print(bio.get_status())
+
+bio.start(
+    "my_pipeline_id",
+    "path/to/my_experiment.mps",
+    "path/to/an/output.mpr",
+)
 ```
 
 ## Using commands over SSH

--- a/aurora_biologic/__init__.py
+++ b/aurora_biologic/__init__.py
@@ -1,9 +1,25 @@
 """Biologic API for Python."""
 
-from .biologic import BiologicAPI
-from .version import __version__
+from aurora_biologic.biologic import (
+    BiologicAPI,
+    get_experiment_info,
+    get_job_id,
+    get_pipelines,
+    get_status,
+    load_settings,
+    start,
+    stop,
+)
+from aurora_biologic.version import __version__
 
 __all__ = [
     "BiologicAPI",
     "__version__",
+    "get_experiment_info",
+    "get_job_id",
+    "get_pipelines",
+    "get_status",
+    "load_settings",
+    "start",
+    "stop",
 ]

--- a/aurora_biologic/biologic.py
+++ b/aurora_biologic/biologic.py
@@ -387,3 +387,88 @@ class BiologicAPI:
             else:
                 job_ids[pid] = None
         return job_ids
+
+
+### Wrapper functions ###
+
+# This allows all functions to be used without explicitly creating a BiologicAPI object
+
+_instance: BiologicAPI | None = None
+
+
+def _get_api() -> BiologicAPI:
+    """Only allow one 'global' API."""
+    global _instance  # noqa: PLW0603
+    _instance = _instance or BiologicAPI()
+    return _instance
+
+
+def get_pipelines(*, show_offline: bool = False) -> dict[str, dict]:
+    """Show pipeline details: index in EC-Lab, serial number, connection status etc.
+
+    Args:
+        show_offline (bool, default: False): Also show offline devices.
+
+    """
+    return _get_api().get_pipelines(show_offline=show_offline)
+
+
+def get_status(
+    pipeline_ids: list[str] | None = None, *, show_offline: bool = False
+) -> dict[str, dict]:
+    """Get the status of the cycling process for all or selected pipelines.
+
+    Args:
+        pipeline_ids (list[str] | None): List of pipeline IDs to get status from.
+            If None, will use the full channel map.
+        show_offline (bool, default: False): Also show offline devices.
+
+    Returns:
+        dict: A dictionary with pipeline IDs as keys and their status as values.
+
+    """
+    return _get_api().get_status(pipeline_ids, show_offline=show_offline)
+
+
+def load_settings(pipeline: str, settings_file: str | Path) -> None:
+    """Load a protocol onto a pipeline."""
+    return _get_api().load_settings(pipeline, settings_file)
+
+
+def run_channel(pipeline: str, output_path: str | Path) -> None:
+    """Run the protocol on the given pipeline."""
+    return _get_api().run_channel(pipeline, output_path)
+
+
+def start(pipeline: str, input_file: str | Path, output_file: str | Path) -> None:
+    """Stop the cycling process on a pipeline."""
+    return _get_api().start(pipeline, input_file, output_file)
+
+
+def stop(pipeline: str) -> None:
+    """Return various experiment info for the job running on the pipeline."""
+    return _get_api().stop(pipeline)
+
+
+def get_experiment_info(pipeline: str) -> tuple[str, str, str, tuple[str | None]]:
+    """Return various experiment info for the job running on the pipeline."""
+    return _get_api().get_experiment_info(pipeline)
+
+
+def get_job_id(
+    pipeline_ids: str | list[str] | None, *, show_offline: bool = False
+) -> dict[str, str | None]:
+    """Get job IDs of selected channels.
+
+    The job ID is the folder name if the job is running, None if it is finished.
+
+    Args:
+        pipeline_ids (list[str] | None): List of pipeline IDs to get status from.
+            If None, will use the full channel map.
+        show_offline (bool, default: False): Also show offline devices.
+
+    Returns:
+        dict: A dictionary with pipeline IDs as keys and Job IDs as values.
+
+    """
+    return _get_api().get_job_id(pipeline_ids, show_offline=show_offline)


### PR DESCRIPTION
Code refactored, and a wrapper functions have been added

Now Python API can be used without creating a class

e.g.
```
import aurora_biologic as bio

bio.start(args)
```

instead of
```
from aurora_biologic import BiologicAPI

with BiologicAPI() as bio:
    bio.start(args)
```