### PR TITLE
Fix status failing

### DIFF
--- a/aurora_biologic/biologic.py
+++ b/aurora_biologic/biologic.py
@@ -284,7 +284,7 @@ class BiologicAPI:
             raise RuntimeError
         return start, end, folder, files
 
-    @retry_with_backoff(delays_s=(0.01, 0.02, 0.03))
+    @retry_with_backoff(delays_s=(0.01,))
     def _olecom_get_status(self, dev_idx: int, channel_idx: int) -> tuple:
         res = self.eclab.MeasureStatus(
             dev_idx,

--- a/aurora_biologic/biologic.py
+++ b/aurora_biologic/biologic.py
@@ -284,7 +284,7 @@ class BiologicAPI:
             raise RuntimeError
         return start, end, folder, files
 
-    @retry_with_backoff()
+    @retry_with_backoff(delays_s=(0.01, 0.02, 0.03))
     def _olecom_get_status(self, dev_idx: int, channel_idx: int) -> tuple:
         res = self.eclab.MeasureStatus(
             dev_idx,
@@ -338,12 +338,15 @@ class BiologicAPI:
         # Get the status of each pipeline and add it to the result dictionary
         status = {}
         for pipeline_id, pipeline_dict in pipeline_dicts.items():
-            status[pipeline_id] = _human_readable_status(
-                self._olecom_get_status(
-                    pipeline_dict["device_index"],
-                    pipeline_dict["channel_index"],
-                ),
-            )
+            try:
+                status[pipeline_id] = _human_readable_status(
+                    self._olecom_get_status(
+                        pipeline_dict["device_index"],
+                        pipeline_dict["channel_index"],
+                    ),
+                )
+            except RuntimeError:  # noqa: PERF203
+                logger.warning("Couldn't get status for pipeline %s from EC-lab", pipeline_id)
 
         return status
 

--- a/aurora_biologic/biologic.py
+++ b/aurora_biologic/biologic.py
@@ -284,6 +284,18 @@ class BiologicAPI:
             raise RuntimeError
         return start, end, folder, files
 
+    @retry_with_backoff()
+    def _olecom_get_status(self, dev_idx: int, channel_idx: int) -> tuple:
+        res = self.eclab.MeasureStatus(
+            dev_idx,
+            channel_idx,
+        )
+        # Status does not fail like other OLE-COM - just returns all 0
+        if all(r == 0 for r in res):
+            msg = "Status is all zero."
+            raise RuntimeError(msg)
+        return res
+
     ### Public API methods ###
 
     def get_pipelines(self, *, show_offline: bool = False) -> dict[str, dict]:
@@ -327,7 +339,7 @@ class BiologicAPI:
         status = {}
         for pipeline_id, pipeline_dict in pipeline_dicts.items():
             status[pipeline_id] = _human_readable_status(
-                self.eclab.MeasureStatus(  # does not have fail state, no retrying
+                self._olecom_get_status(
                     pipeline_dict["device_index"],
                     pipeline_dict["channel_index"],
                 ),

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -59,7 +59,7 @@ class FakeECLab:
 
     def MeasureStatus(self, dev_idx: int, channel_idx: int) -> tuple:
         if dev_idx == 2:
-            return (*[0.0] * 32,)
+            return (1.0, *[0.0] * 31)
         return (
             1.0,
             1.0,

--- a/tests/test_biologic.py
+++ b/tests/test_biologic.py
@@ -114,15 +114,24 @@ def test_get_status(mock_bio) -> None:
     assert len(res) == 0
 
 
-def test_bad_get_status(mock_bio, monkeypatch) -> None:
-    """Test the get_status() function when EC-lab returns all zeros."""
+def test_bad_get_status(mock_bio, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test the get_status function when EC-lab returns all zeros."""
+    original_status = FakeECLab.MeasureStatus
 
-    def _failed_status(*args: tuple) -> tuple:  # noqa: ARG001
-        return (*[0.0] * 32,)
+    def _failed_status(self, dev_idx: int, channel_idx: int) -> tuple:  # noqa: ANN001
+        if dev_idx == 0 and channel_idx == 9:  # MPG2-1-10
+            return (*[0.0] * 32,)
+        return original_status(self, dev_idx, channel_idx)
 
     monkeypatch.setattr(FakeECLab, "MeasureStatus", _failed_status)
-    with pytest.raises(RuntimeError, match="all zero"):
-        bio.get_status("MPG2-1-1")
+
+    bio.get_status("MPG2-1-9")  # One channel passes
+    with pytest.raises(RuntimeError, match="all zero"):  # MPG2-1-10 fails
+        bio.get_status("MPG2-1-10")
+    with pytest.raises(RuntimeError, match="all zero"):  # All fail if one fails
+        bio.get_status(["MPG2-1-10", "MPG2-1-9"])
+    with pytest.raises(RuntimeError, match="all zero"):  # All fail if one fails
+        bio.get_status()
 
 
 def test_load_settings(mock_bio, tmpdir: Path) -> None:

--- a/tests/test_biologic.py
+++ b/tests/test_biologic.py
@@ -114,7 +114,9 @@ def test_get_status(mock_bio) -> None:
     assert len(res) == 0
 
 
-def test_bad_get_status(mock_bio, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_bad_get_status(
+    mock_bio, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test the get_status function when EC-lab returns all zeros."""
     original_status = FakeECLab.MeasureStatus
 
@@ -125,13 +127,23 @@ def test_bad_get_status(mock_bio, monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(FakeECLab, "MeasureStatus", _failed_status)
 
-    bio.get_status("MPG2-1-9")  # One channel passes
-    with pytest.raises(RuntimeError, match="all zero"):  # MPG2-1-10 fails
-        bio.get_status("MPG2-1-10")
-    with pytest.raises(RuntimeError, match="all zero"):  # All fail if one fails
-        bio.get_status(["MPG2-1-10", "MPG2-1-9"])
-    with pytest.raises(RuntimeError, match="all zero"):  # All fail if one fails
-        bio.get_status()
+    res = bio.get_status("MPG2-1-9")  # One channel passes
+    assert len(res) == 1
+
+    caplog.clear()
+    res = bio.get_status("MPG2-1-10")  # MPG2-1-10 fails
+    assert len(res) == 0
+    assert "Couldn't get status" in caplog.text
+
+    caplog.clear()
+    res = bio.get_status(["MPG2-1-10", "MPG2-1-9"])  # Continue if one fails
+    assert len(res) == 1
+    assert "Couldn't get status" in caplog.text
+
+    caplog.clear()
+    res = bio.get_status()  # Continue if one fails
+    assert len(res) == 14
+    assert "Couldn't get status" in caplog.text
 
 
 def test_load_settings(mock_bio, tmpdir: Path) -> None:

--- a/tests/test_biologic.py
+++ b/tests/test_biologic.py
@@ -114,6 +114,17 @@ def test_get_status(mock_bio) -> None:
     assert len(res) == 0
 
 
+def test_bad_get_status(mock_bio, monkeypatch) -> None:
+    """Test the get_status() function when EC-lab returns all zeros."""
+
+    def _failed_status(*args: tuple) -> tuple:  # noqa: ARG001
+        return (*[0.0] * 32,)
+
+    monkeypatch.setattr(FakeECLab, "MeasureStatus", _failed_status)
+    with pytest.raises(RuntimeError, match="all zero"):
+        bio.get_status("MPG2-1-1")
+
+
 def test_load_settings(mock_bio, tmpdir: Path) -> None:
     """Test load_settings() function."""
     mps_path = tmpdir / "settings.mps"


### PR DESCRIPTION
Rarely, EC-lab will return all zeroes for the MeasureStatus command.

Before - this was passed along as-is without retrying, so it would report the channel as stopped.

Now - warn and skip pipeline if all zeroes returned, use backoff like other OLECOM functions.